### PR TITLE
fix unixtimestamp

### DIFF
--- a/api/endpoints/analyze_image.py
+++ b/api/endpoints/analyze_image.py
@@ -4,6 +4,8 @@ from services.analyze_image_service import AnalyzeImage
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from utils.date_util import get_jst_unix_timestamp
+
 router = APIRouter()
 
 # リクエストボディのモデル定義
@@ -14,16 +16,18 @@ class ImagePathRequest(BaseModel):
 @router.post("/")
 async def analyze_image(request: ImagePathRequest,
     repository: AIAnalysisLogRepository = Depends(get_ai_analysis_log_repository)):
+    start_time = get_jst_unix_timestamp()
     analyze_image = AnalyzeImage()
     image_description_response = analyze_image.analyze(request.image_path)
+    end_time = get_jst_unix_timestamp()
     repository.create_ai_analysis_log(
         image_path=request.image_path,
         success=image_description_response.success,
         message=image_description_response.message,
         class_=image_description_response.estimated_data.get("class"),
         confidence=image_description_response.estimated_data.get("confidence"),
-        request_timestamp=0,
-        response_timestamp=0
+        request_timestamp=start_time,
+        response_timestamp=end_time
     )
     
     return image_description_response

--- a/services/analyze_image_service.py
+++ b/services/analyze_image_service.py
@@ -3,7 +3,7 @@ import os
 from pydantic import BaseModel
 from typing import Dict, Any
 import requests
-
+import time
 
 class ImageDescriptionResponse(BaseModel):
     success: bool
@@ -34,6 +34,9 @@ class AnalyzeImage:
 
     # モックAPIの呼び出し(ゆくゆく削除する)
     def _mock_api_call(self,image_path: str) -> ImageDescriptionResponse:
+        #一定時間待ちを作る
+        time.sleep(1)
+        
         # モックレスポンスの生成
         if(self.is_mock_error):
             image_description_response = ImageDescriptionResponse(

--- a/utils/date_util.py
+++ b/utils/date_util.py
@@ -1,0 +1,9 @@
+from datetime import datetime, timezone, timedelta
+
+
+def get_jst_unix_timestamp():
+    JST = timezone(timedelta(hours=+9), 'JST')
+
+    # [サンプル]UNIX秒(UTC)を生成
+    epoch = int(datetime.now(JST).strftime('%s%f')) // 1000000
+    return epoch


### PR DESCRIPTION
# やったこと
- 登録時にtimestampが不正だったのでunix timestamp設定(JST)
- mockは処理遅延(1sec)をあえて発生させる